### PR TITLE
Add `q` as allowed identifier in eslint

### DIFF
--- a/packages/eslint-plugin/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin/lib/config/rules/stylistic-issues.js
@@ -54,7 +54,7 @@ module.exports = {
     {
       min: 2,
       properties: 'always',
-      exceptions: ['x', 'y', 'i', 'j', 't', '_', '$'],
+      exceptions: ['x', 'y', 'i', 'j', 't', 'q', '_', '$'],
     },
   ],
   // Require identifiers to match the provided regular expression


### PR DESCRIPTION
## Description

`q` is a common identifier for a search query param, and it used in many apps across Shopify. 

Previously, we had to do this:

```js
// eslint-disable-next-line
const { data, loading, error } = useSearchPackages({ q: "foo" })
```

This patch makes it less painful to use `q` in Javascript-land.

## Type of change

- [ ] @shopify/eslint-plugin Patch: Bug (non-breaking change which fixes an issue)
- [x] @shopify/eslint-plugin Minor: New feature (non-breaking change which adds functionality)
- [ ] @shopify/eslint-plugin Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
